### PR TITLE
Made bz2 an optional dependency

### DIFF
--- a/allennlp/modules/token_embedders/embedding.py
+++ b/allennlp/modules/token_embedders/embedding.py
@@ -1,7 +1,6 @@
 import io
 import tarfile
 import zipfile
-import bz2
 import lzma
 import gzip
 import re
@@ -427,6 +426,10 @@ class EmbeddingsTextFile(Iterator[str]):
 
             # All the python packages for compressed files share the same interface of io.open
             extension = get_file_extension(main_file_uri)
+            
+            if ".bz2" in extension:
+	            import bz2 # import only when necessary
+            
             package = {
                     '.txt': io,
                     '.vec': io,


### PR DESCRIPTION
bz2 was a hard dependency and it was throwing a "ModuleNotFoundError: No module named '_bz2'." error for me. I made it an optional dependency by moving the import to function level and made sure the dependency is only imported when needed by checking the file extension.

This fixes the issue #2178